### PR TITLE
Move to Creative Commons 4.0

### DIFF
--- a/src/en/us/00-front-toc/01-front.markdown
+++ b/src/en/us/00-front-toc/01-front.markdown
@@ -2,10 +2,10 @@
 
 **Copyright and License**
 
-Copyright © 2010-2022 The OWASP Foundation.
+Copyright © 2010-2023 The OWASP Foundation.
 
 This document is released under the Creative Commons Attribution
-Share Alike 3.0 license. For any reuse or distribution, you must make
+ShareAlike 4.0 International (CC BY-SA 4.0) license. For any reuse or distribution, you must make
 clear to others the license terms of this work.
 
-[http://creativecommons.org/licenses/by-sa/3.0/](http://creativecommons.org/licenses/by-sa/3.0/)
+[https://creativecommons.org/licenses/by-sa/4.0/deed.en](https://creativecommons.org/licenses/by-sa/4.0/deed.en)

--- a/src/en/us/title.pdf.txt
+++ b/src/en/us/title.pdf.txt
@@ -5,7 +5,7 @@ subtitle: Quick Reference Guide
 author: Open Web Application Security Project (OWASP)
 version: 2.0.1
 date: December 2022
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0)
 geometry: "left=3cm,right=2.5cm,top=2cm,bottom=2cm"
 header-includes: |
     \usepackage{fancyhdr}

--- a/src/en/us/title.txt
+++ b/src/en/us/title.txt
@@ -12,5 +12,5 @@ creator:
   text: Keith Turpin
 version: 2.0.1
 date: December 2022
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
 ...

--- a/src/es/uy/00-front-toc/01-front.markdown
+++ b/src/es/uy/00-front-toc/01-front.markdown
@@ -6,7 +6,7 @@
 
 #### Copyright and License ####
 
-Copyright © 2010-2022 The OWASP Foundation.
+Copyright © 2010-2023 The OWASP Foundation.
 
 This document is released under the Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0) license. For any reuse or distribution, you must make
 clear to others the license terms of this work.

--- a/src/es/uy/00-front-toc/01-front.markdown
+++ b/src/es/uy/00-front-toc/01-front.markdown
@@ -8,8 +8,7 @@
 
 Copyright © 2010-2022 The OWASP Foundation.
 
-This document is released under the Creative Commons Attribution
-Share Alike 3.0 license. For any reuse or distribution, you must make
+This document is released under the Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0) license. For any reuse or distribution, you must make
 clear to others the license terms of this work.
 
-[http://creativecommons.org/licenses/by-sa/3.0/](http://creativecommons.org/licenses/by-sa/3.0/)
+[https://creativecommons.org/licenses/by-sa/4.0/deed.es_ES](https://creativecommons.org/licenses/by-sa/4.0/deed.es_ES)

--- a/src/es/uy/title.pdf.txt
+++ b/src/es/uy/title.pdf.txt
@@ -5,7 +5,7 @@ subtitle: Guía de referencia rápida
 author: Open Web Application Security Project (OWASP)
 version: 2.0.1
 date: Diciembre 2022
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0)
 geometry: "left=3cm,right=2.5cm,top=2cm,bottom=2cm"
 header-includes: |
     \usepackage{fancyhdr}

--- a/src/es/uy/title.txt
+++ b/src/es/uy/title.txt
@@ -12,5 +12,5 @@ creator:
   text: Keith Turpin
 version: 2.0.1
 date: Diciembre 2022
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0)
 ...

--- a/src/ko/kr/00-front-toc/01-front.markdown
+++ b/src/ko/kr/00-front-toc/01-front.markdown
@@ -6,7 +6,7 @@ OWASP 시큐어 코딩 규칙
 
 ## 저작권 및 라이센스
 
-Copyright © 2010-2022 The OWASP Foundation.
+Copyright © 2010-2023 The OWASP Foundation.
 
 한글판 Copyright © 2011 The OWASP Korea Chapter.
 

--- a/src/ko/kr/00-front-toc/01-front.markdown
+++ b/src/ko/kr/00-front-toc/01-front.markdown
@@ -10,10 +10,10 @@ Copyright © 2010-2022 The OWASP Foundation.
 
 한글판 Copyright © 2011 The OWASP Korea Chapter.
 
-이 문서는 Creative Commons Attribution ShareAlike 3.0 라이센스에 따라
+이 문서는 Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0) 라이센스에 따라
 발표되었다. 재사용하거나 배포를 할때에는, 다른 사람들에게 이 문서의
 라이센스 조건을 명확하게 해야 한다.
-[http://creativecommons.org/licenses/by-sa/3.0/](http://creativecommons.org/licenses/by-sa/3.0/)
+[https://creativecommons.org/licenses/by-sa/4.0/deed.ko](https://creativecommons.org/licenses/by-sa/4.0/deed.ko)
 
 -   번역 (2011 년 6 월): OWASP Korea 챕터
 -   OWASP Korea 연락처: 최훈진 이사 (gmanhj@ahnlab.com)

--- a/src/ko/kr/title.pdf.txt
+++ b/src/ko/kr/title.pdf.txt
@@ -5,7 +5,7 @@ subtitle: 참고 가이드
 author: Open Web Application Security Project (OWASP)
 version: 2.0.1
 date: 2022 년 12 월
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0)
 geometry: "left=3cm,right=2.5cm,top=2cm,bottom=2cm"
 mainfont: Nanum Myeongjo
 fontsize: 12pt

--- a/src/ko/kr/title.txt
+++ b/src/ko/kr/title.txt
@@ -12,7 +12,7 @@ creator:
   text: Keith Turpin
 version: 2.0.1
 date: 2022 년 12 월
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0)
 geometry: "left=2.3cm,right=2cm,top=2cm,bottom=2.5cm"
 mainfont: Nanum Myeongjo
 fontsize: 12pt

--- a/src/pt/br/00-front-toc/01-front.markdown
+++ b/src/pt/br/00-front-toc/01-front.markdown
@@ -6,7 +6,7 @@
 
 #### Copyright and License
 
-Copyright © 2010-2022 The OWASP Foundation.
+Copyright © 2010-2023 The OWASP Foundation.
 
 O conteúdo deste documento é distribuído sob a licença Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0). Para a utilização ou redistribuição, deve
 deixar claro os termos da licença deste trabalho.

--- a/src/pt/br/00-front-toc/01-front.markdown
+++ b/src/pt/br/00-front-toc/01-front.markdown
@@ -8,8 +8,7 @@
 
 Copyright © 2010-2022 The OWASP Foundation.
 
-O conteúdo deste documento é distribuído sob a licença Creative Commons
-Attribution ShareAlike 3.0. Para a utilização ou redistribuição, deve
+O conteúdo deste documento é distribuído sob a licença Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0). Para a utilização ou redistribuição, deve
 deixar claro os termos da licença deste trabalho.
 
-[http://creativecommons.org/licenses/by-sa/3.0/](http://creativecommons.org/licenses/by-sa/3.0/)
+[https://creativecommons.org/licenses/by-sa/4.0/deed.pt_BR](https://creativecommons.org/licenses/by-sa/4.0/deed.pt_BR)

--- a/src/pt/br/title.pdf.txt
+++ b/src/pt/br/title.pdf.txt
@@ -5,7 +5,7 @@ subtitle: Guia de Referência Rápida
 author: Open Web Application Security Project (OWASP)
 version: 2.0.1
 date: dezembro de 2022
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
 geometry: "left=3cm,right=2.5cm,top=2cm,bottom=2.5cm"
 header-includes: |
     \usepackage{fancyhdr}

--- a/src/pt/br/title.txt
+++ b/src/pt/br/title.txt
@@ -12,5 +12,5 @@ creator:
   text: Keith Turpin
 version: 2.0.1
 date: dezembro de 2022
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
 ...

--- a/src/pt/pt/00-front-toc/01-front.markdown
+++ b/src/pt/pt/00-front-toc/01-front.markdown
@@ -3,12 +3,9 @@
 
 ***Copyright and License***
 
-Copyright © 2010-2022 The OWASP Foundation.
+Copyright © 2010-2023 The OWASP Foundation.
 
-O conteúdo deste documento é distribuído ao abrigo da licença Creative
-Commons Attribution ShareAlike
-
-3.0. Para a utilização ou redistribuição, deve deixar claro os termos da
+O conteúdo deste documento é distribuído ao abrigo da licença Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0). Para a utilização ou redistribuição, deve deixar claro os termos da
 licença deste trabalho.
 
-[http://creativecommons.org/licenses/by-sa/3.0/]
+[https://creativecommons.org/licenses/by-sa/4.0/deed.pt](https://creativecommons.org/licenses/by-sa/4.0/deed.pt)

--- a/src/pt/pt/title.pdf.txt
+++ b/src/pt/pt/title.pdf.txt
@@ -5,7 +5,7 @@ subtitle: Guia de Referência Rápida
 author: Open Web Application Security Project (OWASP)
 version: 2.0.1
 date: dezembro de 2022
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
 geometry: "left=3cm,right=2.5cm,top=2cm,bottom=2.5cm"
 header-includes: |
     \usepackage{fancyhdr}

--- a/src/pt/pt/title.txt
+++ b/src/pt/pt/title.txt
@@ -12,5 +12,5 @@ creator:
   text: Keith Turpin
 version: 2.0.1
 date: dezembro de 2022
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
 ...

--- a/src/zh/cn/00-front-toc/01-front.markdown
+++ b/src/zh/cn/00-front-toc/01-front.markdown
@@ -6,10 +6,10 @@ OWASP 安全编码规范快速参考指南
 
 版权所有：2012-2022 年 OWASP基金会©
 
-本文档基于 Creative Commons Attribution ShareAlike3.0 license 发布。任何重用或发行，  
+本文档基于 Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) license 发布。任何重用或发行，  
 都必须向他人明确该文档的许可条款。
 
-[[http://creativecommons.org/licenses/by-sa/3.0/]{.underline}](http://creativecommons.org/licenses/by-sa/3.0/)
+[[https://creativecommons.org/licenses/by-sa/4.0/deed.zh_TW]{.underline}](https://creativecommons.org/licenses/by-sa/4.0/deed.zh_TW)
 
 # 中文版本团队成员
 

--- a/src/zh/cn/title.pdf.txt
+++ b/src/zh/cn/title.pdf.txt
@@ -5,7 +5,7 @@ subtitle: 快速参考指南
 author: Open Web Application Security Project (OWASP)
 version: 中文版 2.0.1
 date: 2022 年 12 月
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0)
 geometry: "left=2.3cm,right=2cm,top=2cm,bottom=2.5cm"
 mainfont: Songti SC Light
 fontsize: 12pt

--- a/src/zh/cn/title.txt
+++ b/src/zh/cn/title.txt
@@ -12,7 +12,7 @@ creator:
   text: Keith Turpin
 version: 中文版 2.0.1
 date: 2022 年 12 月
-rights:  Creative Commons Non-Commercial Share Alike 3.0
+rights:  Creative Commons Attribution ShareAlike 4.0 International (CC BY-SA 4.0)
 geometry: "left=2.3cm,right=2cm,top=2cm,bottom=2.5cm"
 mainfont: Songti SC Light
 fontsize: 12pt


### PR DESCRIPTION
At present the document is released under Creative Commons Attribution Share Alike version 3.0

This pull request moves the files to "Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)" which is used by project [OWASP Go Secure Coding Practices Guide](https://owasp.org/www-project-go-secure-coding-practices-guide/)

Closes #18 